### PR TITLE
Test for empty input channel

### DIFF
--- a/cirque.go
+++ b/cirque.go
@@ -41,6 +41,7 @@ func NewCirque(parallelism int64, processor func(interface{}) interface{}) (chan
 		}
 
 		aInc(&completeFlag)
+		pushSignal.Broadcast()
 	}()
 
 	go func() { // send outputs in order
@@ -59,7 +60,9 @@ func NewCirque(parallelism int64, processor func(interface{}) interface{}) (chan
 				go popSignal.Broadcast()
 				aInc(&followingIndex)
 			} else {
-				pushSignal.Wait()
+				if aR(&completeFlag) == 0 {
+					pushSignal.Wait()
+				}
 			}
 		}
 	}()

--- a/cirque.go
+++ b/cirque.go
@@ -3,6 +3,7 @@ package cirque
 import (
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // NewCirque creates a FIFO parallel queue that runs a given processor function on each job, similar to a parallel Map.
@@ -24,6 +25,7 @@ func NewCirque(parallelism int64, processor func(interface{}) interface{}) (chan
 	var completeFlag int64 = 0 // ideally a boolean, but we want an atomic variable without typecasts
 	var leadingIndex int64 = 0
 	var followingIndex int64 = 0
+	processingFinished := make(chan struct{})
 
 	go func() { // process all the inputs
 		popSignal.L.Lock()
@@ -41,7 +43,16 @@ func NewCirque(parallelism int64, processor func(interface{}) interface{}) (chan
 		}
 
 		aInc(&completeFlag)
-		pushSignal.Broadcast()
+		// This is to avoid race condition where output channel does not close.
+		for {
+			select {
+			case <-processingFinished:
+				return
+
+			case <-time.After(10 * time.Millisecond):
+				pushSignal.Broadcast()
+			}
+		}
 	}()
 
 	go func() { // send outputs in order
@@ -52,17 +63,17 @@ func NewCirque(parallelism int64, processor func(interface{}) interface{}) (chan
 			if aR(&completeFlag) > 0 && aR(&followingIndex) == aR(&leadingIndex) {
 				// all inputs have been accepted and we've caught up on outputs
 				close(output)
+				processingFinished <- struct{}{}
 				return
 			}
+
 			if value, ok := stagedResults.Load(followingIndex); ok {
 				output <- value
 				go stagedResults.Delete(followingIndex) // clear the map behind us, keeps memory usage constant
 				go popSignal.Broadcast()
 				aInc(&followingIndex)
 			} else {
-				if aR(&completeFlag) == 0 {
-					pushSignal.Wait()
-				}
+				pushSignal.Wait()
 			}
 		}
 	}()

--- a/cirque_test.go
+++ b/cirque_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCirque(t *testing.T) {
-	for j := 0; j < 100; j++ {
+	for j := 0; j < 1000; j++ {
 		inputs := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 		expectedOutput := []int{2, 4, 6, 8, 10, 12, 14, 16, 18, 20}
 
@@ -19,7 +19,7 @@ func TestCirque(t *testing.T) {
 		var maxParallelism int64 = 3
 		inputChannel, outputChannel := NewCirque(maxParallelism, func(i interface{}) interface{} {
 			atomic.AddInt64(&measuredParallelism, 1)
-			time.Sleep(time.Duration(rand.Int63n(100)) * time.Millisecond)
+			time.Sleep(time.Duration(rand.Int63n(10)) * time.Millisecond)
 			atomic.AddInt64(&measuredParallelism, -1)
 			return i.(int) * 2
 		})
@@ -47,7 +47,7 @@ func TestCirque(t *testing.T) {
 }
 
 func TestCirqueNoInput(t *testing.T) {
-	for j := 0; j < 100; j++ {
+	for j := 0; j < 1000; j++ {
 		inputs := []int{}
 
 		var measuredParallelism int64 = 0
@@ -55,7 +55,7 @@ func TestCirqueNoInput(t *testing.T) {
 		var maxParallelism int64 = 3
 		inputChannel, outputChannel := NewCirque(maxParallelism, func(i interface{}) interface{} {
 			atomic.AddInt64(&measuredParallelism, 1)
-			time.Sleep(time.Duration(rand.Int63n(100)) * time.Millisecond)
+			time.Sleep(time.Duration(rand.Int63n(10)) * time.Millisecond)
 			atomic.AddInt64(&measuredParallelism, -1)
 			return i.(int) * 2
 		})


### PR DESCRIPTION
Cirque seems to be blocking sometime when no input is passed in the input channel. Added the test cases. We need to debug the issue.


<img width="978" alt="Screenshot 2019-11-18 at 6 51 56 PM" src="https://user-images.githubusercontent.com/9051383/69055951-fbf5f980-0a34-11ea-8a4c-a2b9240ebb26.png">
