### PR TITLE
close output channel when input channel is empty

### DIFF
--- a/cirque.go
+++ b/cirque.go
@@ -39,7 +39,7 @@ func NewCirque(parallelism int64, processor func(interface{}) interface{}) (chan
 			}(leadingIndex, job)
 			aInc(&leadingIndex)
 		}
-
+		pushSignal.Broadcast() // when input channel is empty, broadcast push event to close output channel
 		aInc(&completeFlag)
 	}()
 


### PR DESCRIPTION
When the input channel is empty, output channel is not closed as it is waiting for the broadcast signal https://github.com/sudhirj/cirque/blob/9544ba09991a15e7fa7aa91834f1e922f446f2f9/cirque.go#L62
To solve this, I broadcasted push event at end of input channel so that pushSignal wait will get terminated and output channel will get closed.